### PR TITLE
ci: refine workflow triggers for the `publish` branch by removing pus…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches-ignore: [publish]
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish Libs
 
 on:
-  push:
-    branches: [publish]
   pull_request:
     branches: [publish]
 


### PR DESCRIPTION
…h triggers from the publish workflow and ignoring publish branch PRs in the CI workflow.