### PR TITLE
ci(publish): add nest-audit packaging and sequential release orchestration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,49 @@ permissions:
   actions: read
 
 jobs:
+  nest-audit:
+    name: Build & Verify nest-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Test @nest-util/nest-audit
+        run: pnpm nx test @nest-util/nest-audit
+
+      - name: Build @nest-util/nest-audit
+        run: pnpm nx build @nest-util/nest-audit
+
+      - name: Create Tarball
+        run: |
+          cp libs/nest-audit/package.json libs/nest-audit/dist/package.json
+          cd libs/nest-audit/dist
+          # Fix paths in package.json to be relative to the current folder (dist)
+          jq '(.main, .module, .types, .exports["."].types, .exports["."].import, .exports["."].default) |= sub("^\\./dist/"; "./") | del(.files) | del(.exports["."]["@nest-util/source"])' package.json > package.json.tmp && mv package.json.tmp package.json
+          pnpm pack --pack-destination ../../../
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nest-audit-tgz
+          path: nest-util-nest-audit-*.tgz
+          retention-days: 7
+
   nest-crud:
     name: Build & Verify nest-crud
+    needs: nest-audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,12 +75,21 @@ jobs:
       - name: Build @nest-util/nest-crud
         run: pnpm nx build @nest-util/nest-crud
 
+      - name: Download nest-audit package
+        uses: actions/download-artifact@v4
+        with:
+          name: nest-audit-tgz
+          path: ./artifacts
+
+      - name: Validate nest-audit artifact exists
+        run: ls -1 ./artifacts/nest-util-nest-audit-*.tgz
+
       - name: Create Tarball
         run: |
           cp libs/nest-crud/package.json libs/nest-crud/dist/package.json
           cd libs/nest-crud/dist
           # Fix paths in package.json to be relative to the current folder (dist)
-          jq '(.main, .module, .types, .exports["."].types, .exports["."].import, .exports["."].default) |= sub("^\\./dist/"; "./") | del(.files) | del(.exports["."]["@nest-util/source"])' package.json > package.json.tmp && mv package.json.tmp package.json
+          jq '(.main, .module, .types, .exports["."].types, .exports["."].import, .exports["."].default) |= sub("^\\./dist/"; "./") | .peerDependencies["@nest-util/nest-audit"] = "^0.0.1" | del(.files) | del(.exports["."]["@nest-util/source"])' package.json > package.json.tmp && mv package.json.tmp package.json
           pnpm pack --pack-destination ../../../
         
       - name: Upload Artifact
@@ -48,17 +98,6 @@ jobs:
           name: nest-crud-tgz
           path: nest-util-nest-crud-*.tgz
           retention-days: 7
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: latest
-          files: |
-            nest-util-nest-crud-*.tgz
-          prerelease: true
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ncnu:
     name: Build & Verify ncnu
@@ -98,16 +137,6 @@ jobs:
           name: ncnu-tgz
           path: ncnu-*.tgz
           retention-days: 7
-
-      - name: Update Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: latest
-          files: |
-            ncnu-*.tgz
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   nest-auth:
     name: Build & Verify nest-auth
@@ -149,12 +178,49 @@ jobs:
           path: nest-util-nest-auth-*.tgz
           retention-days: 7
 
-      - name: Update Release
+  release:
+    name: Publish release assets
+    runs-on: ubuntu-latest
+    needs:
+      - nest-audit
+      - nest-crud
+      - ncnu
+      - nest-auth
+    steps:
+      - name: Download nest-audit artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nest-audit-tgz
+          path: ./release-artifacts
+
+      - name: Download nest-crud artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nest-crud-tgz
+          path: ./release-artifacts
+
+      - name: Download ncnu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ncnu-tgz
+          path: ./release-artifacts
+
+      - name: Download nest-auth artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nest-auth-tgz
+          path: ./release-artifacts
+
+      - name: Publish combined release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
           files: |
-            nest-util-nest-auth-*.tgz
+            release-artifacts/nest-util-nest-audit-*.tgz
+            release-artifacts/nest-util-nest-crud-*.tgz
+            release-artifacts/ncnu-*.tgz
+            release-artifacts/nest-util-nest-auth-*.tgz
           prerelease: true
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Ensure `@nest-util/nest-audit` is distributable without publishing to npm by building and packaging it in the repo `publish` workflow and installing it alongside other nest-util artifacts. 
- Preserve monorepo `workspace:*` semantics in source while preventing `workspace:*` values from leaking into released tarballs.

### Description
- Added a new `nest-audit` job in `.github/workflows/publish.yml` that runs tests, builds `@nest-util/nest-audit`, creates a tarball and uploads it as `nest-audit-tgz`.
- Made `nest-crud` depend on `nest-audit` via `needs: nest-audit`, downloaded the `nest-audit` artifact in the `nest-crud` job, and validated its presence so dependency order is explicit.
- Kept `libs/nest-crud/package.json` using `"@nest-util/nest-audit": "workspace:*"` in source, and updated the `nest-crud` packaging `jq` transform to rewrite the peer dependency to `"^0.0.1"` only in the packaged artifact to avoid `workspace:*` in releases.
- Replaced per-job release uploads with a single `release` job that `needs` all package jobs and publishes all tarballs together, allowing package jobs to run in parallel when possible and serializing release publication.

### Testing
- Verified the repository diffs with `git diff -- libs/nest-crud/package.json .github/workflows/publish.yml` to inspect the applied changes.
- Exercised the packaging transform in a temporary directory using `jq` to produce `out.json` and confirmed `jq -r '.peerDependencies["@nest-util/nest-audit"]' out.json` returned `^0.0.1`.
- Confirmed the `publish.yml` job ordering and artifact download steps by inspecting the workflow file and ensuring `nest-crud` has `needs: nest-audit` and the combined `release` job depends on all package jobs.
- Attempted to parse the workflow with a Python `yaml.safe_load` check but the runner lacked `PyYAML`, so syntax validation was done via manual inspection and `jq`-based transform testing instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69901b641bf4832082bac95afabf9278)